### PR TITLE
Updated Xbox360 DAC Algorithm to enable `up2` in addition to `up`.

### DIFF
--- a/src/dac_algorithms/xbox_360.cpp
+++ b/src/dac_algorithms/xbox_360.cpp
@@ -6,6 +6,9 @@ namespace Xbox360 {
 // Back is inaccessible, idk whether that's a problem, is it *ever* mandatory in place of B ?
 
 void actuateXbox360Report(GpioToButtonSets::F1::ButtonSet buttonSet) {
+    
+    buttonSet.up = buttonSet.up || buttonSet.up2;
+    
     bool left = buttonSet.left && !(buttonSet.ms);
     bool right = buttonSet.right && !(buttonSet.ms);
     bool up = buttonSet.up && !(buttonSet.ms);


### PR DESCRIPTION
# Title
Add missing up2 Button to Xbox360 DAC Algorithm.

## Description
The up2 button is not enabled when using the Xbox360 DAC Algorithm. This change will enable the up2 button to duplicate functionality of up button.
As the Xbox360 profile uses neutral SOCD resolution, this doesn't affect that behavior

### Affected Modes
- [X] A button (Xbox360/Xbox360) 
- [X] Any additional custom modes using Xbox360 DAC Algorithm

### Testing done
- Verified behavior when holding A, plugging into PC via Steam (identified as Xbox 360 controller, all mapped buttons recognized)
- Verified behavior when holding A, plugging into PC via [gamepad-tester.com](https://gamepad-tester.com) (identified as Xbox 360 Controller, all mapped buttons recognized)
- Verified behavior when holding A, plugging into PC via Brooks Wingman XB (identified as Xbox 360 Controller immediately, all mapped buttons recognized)
- Verified behavior when holding A, plugging into Xbox One via Brooks Wingman XB (identified as Xbox 360 Controller immediately, all mapped buttons recognized)

### Not working
- When holding A, plugging into Playstation4 Pro via Brooks Wingman XE (no response from console, no Home/PS button is mapped, so impossible to launch profile select)
    - Matches behavior in upstream (bjart) repo
    - Does **not** match behavior in upstream (arte) from that!
- When holding A, plugging into PC via Brooks Wingman XE and [gamepad-tester.com](https://gamepad-tester.com) (A button shows as being held when controller is recognized, then does not turn off when released. No other button signals appear to be received after that)
    - Matches behavior in upstream (bjart) repo
    - Does **not** match behavior in upstream (arte) from that!