### PR TITLE
Better USB Latency, fixes (adds?) PlayStation Brooks Wingman Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ As of this release, 13 modes are built-in.
 - Playing Ult on Switch or PC => Ultimate + Adapter mode
 - Playing other PC games => Melee + HID or 8KeysSet + Keyboard
 - Playing other games on Switch => WFPP + WFPP
-- Playing other games on Xbox (requires Brooks Wingman XB) => Xbox360 + Xbox360 or Melee + Xbox360 or WFPP + WFPP
+- Playing other games on Xbox (requires Brooks Wingman XB) => Xbox360 + Xbox360 or Melee + Xbox360
 - Playing other games on PlayStation (requires Brooks Wingman XE) => Xbox360 + Xbox360 or WFPP + WFPP
 - Playing Melee/P+ on PC on the same setup as someone using a Gamecube controller and therefore an adapter => Melee/P+ + HID & configure the HID
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ As of this release, 13 modes are built-in.
 - Playing Ult on Switch or PC => Ultimate + Adapter mode
 - Playing other PC games => Melee + HID or 8KeysSet + Keyboard
 - Playing other games on Switch => WFPP + WFPP
+- Playing other games on Xbox (requires Brooks Wingman XB) => Xbox360 + Xbox360 or Melee + Xbox360 or WFPP + WFPP
+- Playing other games on PlayStation (requires Brooks Wingman XE) => Xbox360 + Xbox360 or WFPP + WFPP
 - Playing Melee/P+ on PC on the same setup as someone using a Gamecube controller and therefore an adapter => Melee/P+ + HID & configure the HID
 
 Configuring the HID means: selecting the Frame1 profile in top right corner of the configuration window (Controllers > Standard Controller > Configure), changing the selecfed device to "pico-rectangle - HID with triggers" and reconfiguring the Control stick Up/Down & C-Stick Up/Down inputs.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Frame1/B0XX layout style public-source digital controller software for the Raspberry Pi Pico (v1.2.4)
 
-This is a modular, runtime-remappable and easily extensible digital controller software for the Raspberry Pi Pico, that can identify as various controllers and communicate over the Joybus (Gamecube/Wii) and USB protocols and using various conversion logics, namely at least Melee, P+, Ultimate, generic controller and generic keyboard.
+This is a modular, runtime-remappable and easily extensible digital controller software for the Raspberry Pi Pico, that can identify as various controllers such as a GCC to USB adapter, an Xbox controller, a Switch pro-like controller, a generic controller and keyboard and communicate over the Joybus (Gamecube/Wii) and USB protocols and using various conversion logics, namely at least Melee, P+, Ultimate.
 
 - [Legal information and license](#legalInformationAndLicense)
 - [Firmware explanation](#firmwareexplanation)  

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Frame1/B0XX layout style public-source digital controller software for the Raspberry Pi Pico (v1.0)
+# Frame1/B0XX layout style public-source digital controller software for the Raspberry Pi Pico (v1.2.4)
 
 - [Legal information and license](#legalInformationAndLicense)
 - [Firmware explanation](#firmwareexplanation)  

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Frame1/B0XX layout style public-source digital controller software for the Raspberry Pi Pico (v1.2.4)
 
+This is a modular, runtime-remappable and easily extensible digital controller software for the Raspberry Pi Pico, that can identify as various controllers and communicate over the Joybus (Gamecube/Wii) and USB protocols and using various conversion logics, namely at least Melee, P+, Ultimate, generic controller and generic keyboard.
+
 - [Legal information and license](#legalInformationAndLicense)
 - [Firmware explanation](#firmwareexplanation)  
 - [Safety information](#safetyInformation)  
@@ -15,8 +17,6 @@
 - [How to wire the board](#howToWireTheBoard)
 - [Troubleshooting](#troubleshooting)
 - [Contact](#contact)
-
-This is a modular, runtime-remappable and easily extensible digital controller software for the Raspberry Pi Pico, that can identify as various controllers and communicate over the Joybus (Gamecube/Wii) and USB protocols and using various conversion logics, namely at least Melee, P+, Ultimate, generic controller and generic keyboard.
 
 <a name="legalInformationAndLicense"/>
 


### PR DESCRIPTION
# Description
Pull upstream https://github.com/JulienBernard3383279/pico-rectangle/commit/90d423ff2a7b342440f7b9c1b1efb80b9ccd17de into https://github.com/rana-sylvatica/pico-rectangle-rana-digital/commit/4abd50fafa183a6cafda1892aecc09bab7496654

## Changes
Update Communications Protocols -> USB by @JulienBernard3383279 
Update README -> Advised Modes -> PlayStation
Update README -> Advised Modes -> Xbox

### Affected Modes
#### Console
- [ ] Nothing Pressed - Melee (Joybus) mode
- [ ] GP2 - P+ (Joybus) mode
- [ ] GP6 - Ultimate (Joybus) mode
- [ ] GP7 - P+ mode
#### USB
I _think_ this affects all USB modes. It was advertised as improvements to Switch Adapter latency but also fixed the Brooks Wingman XE not registering any buttons after the first one. It probably even applies to remapping and BOOTSEL.
- [x] Nothing Pressed - Melee (Adapter) mode
- [x] GP0 - 8KRO Keyboard
- [x] GP2 - Wired Fight Pad Pro with P+
- [x] GP4 - Wired Fight Pad Pro (dedicated)
- [x] GP5 - Wired Fight Pad Pro with Melee
- [x] GP6 - Ultimate (Adapter) mode
- [x] GP7 - P+ (Adapter) mode
- [x] GP13 - XInput with Melee
- [x] GP14 - XInput (dedicated Xbox360)
- [ ] GP16 - BOOTSEL
- [ ] GP17 - Runtime Remapping
- [x] GP20 - HID Controller with P+
- [x] GP21 - HID Controller with Melee
- [x] GP22 - HID Controller with Ultimate
- [x] Any other future modes using the USB communications protocol

### Testing done
- Verified behavior when holding `Left`, plugging into PC via Brooks Wingman XE (identified as Wingman Converter XE, all mapped buttons recognized)
- Verified behavior when holding `Left`, plugging into PlayStation4 Pro via Brooks Wingman XE (press `Start` to launch profile select, all mapped buttons recognized)
- Verified behavior when holding `A`, plugging into PC via Brooks Wingman XE on [gamepad-tester.com](https://gamepad-tester.com/) (identified as Wingman XE, all mapped buttons recognized)
- Verified behavior when holding `A`, plugging into PlayStation4 Pro via Brooks Wingman XE (press `Start` to launch profile select, all mapped buttons recognized)

### How to reproduce this
1. Hold `Left` button while plugging into PlayStation (using a Brooks Wingman XE) to enter WFPP dedicated mode.
2. Press `Start`
    1. Verify profile select launches and all buttons are mapped.
3. Hold `A` button while plugging into PlayStation (using a Brooks Wingman XE) to enter Xbox360 dedicated mode.
4. Press `Start` + `MS`
    1. Verify profile select launches and all buttons are mapped.

### Known Issues
None