### PR TITLE
Update jugeeya's loop to rename project, and make NO_REAC more explicit in filename.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(pico_sdk_import.cmake)
 
 pico_sdk_init()
 
-project(pico_rectangle CXX C)
+project(doyouknowb0xxy CXX C)
 include_directories(include pico-joybus-comms/include)
 
 # Define the options as a list
@@ -16,10 +16,10 @@ set(ULT_OPTIONS "ULT_2IP_NO_REAC" "ULT_2IP_WITH_REAC" "ULT_NEUTRAL")
 # Loop through the options and create a target for each one
 foreach(ULT_OPTION ${ULT_OPTIONS})
   # Create a target name for the current option
-  set(TARGET_NAME "pico_rectangle_${ULT_OPTION}")
+  set(TARGET_NAME "doyouknowb0xxy_${ULT_OPTION}")
   # If this is the default option, set the output file name to "pico_rectangle"
   if(${ULT_OPTION} STREQUAL "ULT_2IP_NO_REAC")
-    set(TARGET_NAME "pico_rectangle")
+    set(TARGET_NAME "doyouknowb0xxy_${ULT_OPTION}")
   endif()
   
   # Add an executable target for the current option


### PR DESCRIPTION
# Description
Update name of project and filename suffix for NO_REAC mode.

## Changes
CMakeLists.txt

### Affected Modes
#### Console
- [ ] Nothing Pressed - Melee (Joybus) mode
- [ ] GP2 - P+ (Joybus) mode
- [X] GP6 - Ultimate (Joybus) mode
- [ ] GP7 - P+ mode
#### USB
- [ ] Nothing Pressed - Melee (Adapter) mode
- [ ] GP0 - 8KRO Keyboard
- [ ] GP2 - Wired Fight Pad Pro with P+
- [ ] GP4 - Wired Fight Pad Pro (dedicated)
- [ ] GP5 - Wired Fight Pad Pro with Melee
- [X] GP6 - Ultimate (Adapter) mode
- [ ] GP7 - P+ (Adapter) mode
- [ ] GP13 - XInput with Melee
- [ ] GP14 - XInput (dedicated Xbox360)
- [ ] GP16 - BOOTSEL
- [ ] GP17 - Runtime Remapping
- [ ] GP20 - HID Controller with P+
- [ ] GP21 - HID Controller with Melee
- [ ] GP22 - HID Controller with Ultimate
- [ ] Any other future modes using the Xbox360 DAC Algorithm

### Testing done
Include the steps you took to verify that your changes are operating as intended. Make sure you've covered all possible regressions.
- Flashed an RD