### PR TITLE
Add Xbox360 Leverless mode

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,7 @@ Check the boxes for any mode that is affected by your changes. Make sure to note
 - [ ] GP5 - Wired Fight Pad Pro with Melee
 - [ ] GP6 - Ultimate (Adapter) mode
 - [ ] GP7 - P+ (Adapter) mode
+- [ ] GP12 - XInput (leverless fightstick)
 - [ ] GP13 - XInput with Melee
 - [ ] GP14 - XInput (dedicated Xbox360)
 - [ ] GP16 - BOOTSEL

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,7 +23,7 @@ Check the boxes for any mode that is affected by your changes. Make sure to note
 - [ ] GP5 - Wired Fight Pad Pro with Melee
 - [ ] GP6 - Ultimate (Adapter) mode
 - [ ] GP7 - P+ (Adapter) mode
-- [ ] GP12 - XInput (leverless fightstick)
+- [ ] GP12 - XInput (Leverless Fightstick via Xbox360)
 - [ ] GP13 - XInput with Melee
 - [ ] GP14 - XInput (dedicated Xbox360)
 - [ ] GP16 - BOOTSEL

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ If you reconnect the board in BOOTSEL mode, you won't see the .uf2 file anymore.
 
 ### Modes
 
-As of this release, 15 modes are built-in.
+As of this release, 16 modes are built-in.
 
 - GP16 (by default, CRight) => BOOTSEL mode. This allows for updating the firmware without taking apart the controller to access the Pico.
 
@@ -123,6 +123,8 @@ As of this release, 15 modes are built-in.
 
 - GP13 (by default, CLeft) => XInput (Melee DAC algorithm + Xbox360 USB configuration). See lower for mapping.
 
+- GP12 (by default, CUp) => XInput (Xbox360 DAC algorithm + Xbox360 Leverless configuration). See lower for mapping.
+
 - Plugged into USB, nothing pressed => Melee GCC to USB adapter mode (Melee F1 DAC algorithm + Adapter USB configuration).
 
 <a name="advisedModes"/>
@@ -131,10 +133,10 @@ As of this release, 15 modes are built-in.
 - Playing Melee resp. P+ on console => Melee resp. P+ + Joybus
 - Playing Melee resp. P+ on PC => Melee resp. P+ + Adapter mode
 - Playing Ult on Switch or PC => Ultimate + Adapter mode
-- Playing other PC games => XInput or 8KeysSet + Keyboard
 - Playing other games on Switch => WFPP + WFPP
-- Playing other games on Xbox (requires Brooks Wingman XB) => Xbox360 + Xbox360 or Melee + Xbox360
-- Playing other games on PlayStation (requires Brooks Wingman XE) => Xbox360 + Xbox360 or WFPP + WFPP
+- Playing other games on PC => XInput (USB or Leverless) or 8KeysSet + Keyboard
+- Playing other games on Xbox (requires Brooks Wingman XB) => XInput or Melee + Xbox360
+- Playing other games on PlayStation (requires Brooks Wingman XE) => XInput or WFPP + WFPP
 - Playing Melee/P+ on PC on the same setup as someone using a Gamecube controller and therefore an adapter => Melee/P+ + HID & configure the HID
 
 Configuring the HID means: selecting the Frame1 profile in top right corner of the configuration window (Controllers > Standard Controller > Configure), changing the selecfed device to "pico-rectangle - HID with triggers" and reconfiguring the Control stick Up/Down & C-Stick Up/Down inputs.
@@ -203,17 +205,28 @@ Button mappings:
 
 ### XInput mode logic
 
-XInput mode is meant to provide extra compatibility options for PC and the Xbox family of consoles (Brooks Wingman XB required) by identifying as an Xbox 360 Controller.
+XInput mode is meant to provide extra compatibility options for PC and the Xbox family of consoles (Brooks Wingman XB required) by identifying as an Xbox 360 Controller. Movement controls map to the left *stick*, and the C buttons map to the right stick.
 
-With the Melee F1 DAC algorithm, Start is mapped to Start (Menu). L, R and Z are respectively mapped to LT, RT and ZR (RB). ZR (LB), Back (View), Home, LS Press, and RS Press are inaccessible.
+With the Melee F1 DAC algorithm, Start is mapped to Start (Menu). L, R and Z are respectively mapped to LT, RT and ZR (RB).
+*ZR (LB), Back (View), Home, LS Press, and RS Press are inaccessible.*
 
-In dedicated mode, Modifiers and LS/MS are repurposed. This means you can only access cardinals and diagonals on the control stick. Start, B and the control stick have additional buttons mapped when combined with MS.
-- LS => ZL (LB)
-- Z => ZR (RB)
-- L => LT
+In Xbox360 mode, Modifiers and LS/MS are repurposed. This means you can only access cardinals and diagonals on the control stick.
+*Start, B and the control stick have additional buttons mapped when combined with MS.*
+
+- B => B
+- X => X
 - R => RT
+- Y => Y
+- Z => ZR (RB)
+- LS => ZL (LB)
+- Up => Up
+- MS => modifier
+
+- L => LT
 - MX => LS Press
 - MY => RS Press
+- A => A
+
 - Start => Start (Menu)
 - MS and Start => Home (Xbox)
 - MS and B => Back (View)
@@ -221,6 +234,37 @@ In dedicated mode, Modifiers and LS/MS are repurposed. This means you can only a
 - MS and Right => Dpad right
 - MS and Up => Dpad up
 - MS and Down => Dpad down
+
+#### Leverless mapping
+
+XInput can also function as a leverless fightstick, offering a different default button mapping. It still is technically an Xbox controller, so you have two analog sticks and a d-pad for movement options, and movement is set to the left *stick*. It doesn't use the "melee-style" layout and is a little easier to remap and play other genres in.
+
+The face buttons are mapped directly to the first four buttons on the right hand, with the L/R triggers on the top two right most buttons, and L/R bumpers immediately underneath them.
+
+In this scheme you can only access cardinals and diagonals on the control sticks. 
+*Start, MX and the control stick have additional buttons mapped when combined with L.*
+
+- B => A
+- X => B
+- R => X
+- Y => Y
+- Z => ZL (LB)
+- LS => LT
+- Up => ZR (RB)
+- MS => RT
+
+- L => modifier
+- MX => LS Press
+- MY => Up (like a traditional hitbox-style)
+- A => RS Press
+
+- Start => Start (Menu)
+- L and Start => Home (Xbox)
+- L and MY => Back (View)
+- L and Left => Dpad left
+- L and Right => Dpad right
+- L and Up => Dpad up
+- L and Down => Dpad down
 
 <a name="adapterModeInformation"/>
 

--- a/include/dac_algorithms/xbox_360.hpp
+++ b/include/dac_algorithms/xbox_360.hpp
@@ -8,9 +8,9 @@
 namespace DACAlgorithms {
 namespace Xbox360 {
 
-// Back is inaccessible, idk whether that's a problem
-
 void actuateXbox360Report(GpioToButtonSets::F1::ButtonSet buttonSet);
+
+void actuateLeverlessReport(GpioToButtonSets::F1::ButtonSet buttonSet);
 
 }
 }

--- a/src/dac_algorithms/xbox_360.cpp
+++ b/src/dac_algorithms/xbox_360.cpp
@@ -48,5 +48,69 @@ void actuateXbox360Report(GpioToButtonSets::F1::ButtonSet buttonSet) {
 	xInputReport.rightStickY = buttonSet.cDown && buttonSet.cUp ? 0 : buttonSet.cDown ? 0x8000 : buttonSet.cUp ? 0x7FFF : 0;
 };
 
+// Map face and shoulder buttons to top two rows on right side. We're a fightstick now.
+// Use up2 for up to appease WASD players.
+// Use MY for up to appease Hitbox players.
+// MX and A are LS Press and RS Press.
+// L is a modifier: L+Start = Home, L+Left/Right/Up/Down = Dpad left/right/up/down, L+MY = Back
+void actuateLeverlessReport(GpioToButtonSets::F1::ButtonSet buttonSet) {
+
+    // Modifier button is L
+    bool mod = buttonSet.l;
+
+    // up -> RB (you can always have too many ups)
+    bool zr = buttonSet.up;
+
+    // up2 -> up
+    // MY -> up (you can never have too many ups)
+    buttonSet.up = (buttonSet.up2 || buttonSet.my);
+
+    bool left = buttonSet.left && !(mod);
+    bool right = buttonSet.right && !(mod);
+    bool up = buttonSet.up && !(mod);
+    bool down = buttonSet.down && !(mod);
+
+    // Left stick + Modifer button -> D-Pad
+    bool dLeft = buttonSet.left && mod;
+    bool dRight = buttonSet.right && mod;
+    bool dUp = buttonSet.up && mod;
+    bool dDown = buttonSet.down && mod;
+
+    // Start +/- Modifier button -> Home / Photo
+    bool start = buttonSet.start && (!mod);
+    bool home = buttonSet.start && mod;
+
+    // MX / A / MX + Modifier Button -> LS Press / RS Press / Back
+    bool l3 = buttonSet.mx && (!mod);
+    bool r3 = buttonSet.a;
+    bool back = buttonSet.mx && mod;
+
+    USBConfigurations::Xbox360::ControllerReport &xInputReport = USBConfigurations::Xbox360::xInputReport;
+    xInputReport.reportId = 0;
+    xInputReport.rightStickPress = r3;
+    xInputReport.leftStickPress = l3;
+    xInputReport.back = back;
+    xInputReport.start = start;
+    xInputReport.dRight = dRight;
+    xInputReport.dLeft = dLeft;
+    xInputReport.dDown = dDown;
+    xInputReport.dUp = dUp;
+    xInputReport.zl = buttonSet.z;
+    xInputReport.zr = zr;
+    xInputReport.home = home;
+    xInputReport.pad1 = 0;
+    xInputReport.a = buttonSet.b;
+    xInputReport.b = buttonSet.x;
+    xInputReport.x = buttonSet.r;
+    xInputReport.y = buttonSet.y;
+    xInputReport.leftTrigger = buttonSet.ls ? 255 : 0;
+    xInputReport.rightTrigger = buttonSet.ms ? 255 : 0;
+    xInputReport.leftStickX = left && right ? 0 : left ? 0x8000 : right ? 0x7FFF : 0; // Neutral SOCD 
+    xInputReport.leftStickY = down && up ? 0x7FFF : down ? 0x8000 : up ? 0x7FFF : 0; // Up overrides down
+    xInputReport.rightStickX = buttonSet.cLeft && buttonSet.cRight ? 0 : buttonSet.cLeft ? 0x8000 : buttonSet.cRight ? 0x7FFF : 0; // Neutral SOCD 
+    xInputReport.rightStickY = buttonSet.cDown && buttonSet.cUp ? 0x7FFF : buttonSet.cDown ? 0x8000 : buttonSet.cUp ? 0x7FFF : 0; // Up overrides down
+};
+
+
 }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,7 +56,7 @@ int main() {
     #endif
     ;
 
-    std::vector<uint8_t> modePins = { 22, 21, 20, 16, 17, 14, 13, 7, 6, 5, 4, 2, keyboardPin }; // DO NOT USE PIN GP15
+    std::vector<uint8_t> modePins = { 22, 21, 20, 16, 17, 14, 13, 12, 7, 6, 5, 4, 2, keyboardPin }; // DO NOT USE PIN GP15
 
     for (uint8_t modePin : modePins) {
         gpio_init(modePin);
@@ -112,6 +112,11 @@ int main() {
     // 19 - GP14 - A - Xbox360/Xbox360 (aka XInput)
     if (!gpio_get(14)) USBConfigurations::Xbox360::enterMode([](){
         DACAlgorithms::Xbox360::actuateXbox360Report(GpioToButtonSets::F1::defaultConversion());
+    });
+
+    // ? - GP12 - CUp - Leverless/Xbox360 (aka XInput)
+    if (!gpio_get(12)) USBConfigurations::Xbox360::enterMode([](){
+        DACAlgorithms::Xbox360::actuateLeverlessReport(GpioToButtonSets::F1::defaultConversion());
     });
 
     // 27 - GP21 - X - Melee / HID


### PR DESCRIPTION
# Description
New layout and mode for XInput DAC + Leverless fightstick layout.

## Changes
Update DAC Algorithms -> XInput (add Leverless layout)

### Affected Modes
#### Console
- [ ] Nothing Pressed - Melee (Joybus) mode
- [ ] GP2 - P+ (Joybus) mode
- [ ] GP6 - Ultimate (Joybus) mode
- [ ] GP7 - P+ mode
#### USB
- [ ] Nothing Pressed - Melee (Adapter) mode
- [ ] GP0 - 8KRO Keyboard
- [ ] GP2 - Wired Fight Pad Pro with P+
- [ ] GP4 - Wired Fight Pad Pro (dedicated)
- [ ] GP5 - Wired Fight Pad Pro with Melee
- [ ] GP6 - Ultimate (Adapter) mode
- [ ] GP7 - P+ (Adapter) mode
- [X] GP13 - XInput with Leverless fightstick
- [ ] GP13 - XInput with Melee
- [ ] GP14 - XInput (dedicated Xbox360)
- [ ] GP16 - BOOTSEL
- [ ] GP17 - Runtime Remapping
- [ ] GP20 - HID Controller with P+
- [ ] GP21 - HID Controller with Melee
- [ ] GP22 - HID Controller with Ultimate
- [ ] Any other future modes using the Xbox360 DAC Algorithm

### Testing done
- Gamepad tester checks out after flashing