### PR TITLE
Update Xbox360 Leverless button mapping, Mod (L) + R (used to be star…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,14 +16,14 @@ Check the boxes for any mode that is affected by your changes. Make sure to note
 - [ ] GP6 - Ultimate (Joybus) mode
 - [ ] GP7 - P+ mode
 #### USB
-- [ ] Nothing Pressed - Melee (Adapter) mode
+- [ ] Nothing Pressed - XInput (Leverless Fightstick via Xbox360)
 - [ ] GP0 - 8KRO Keyboard
 - [ ] GP2 - Wired Fight Pad Pro with P+
 - [ ] GP4 - Wired Fight Pad Pro (dedicated)
 - [ ] GP5 - Wired Fight Pad Pro with Melee
 - [ ] GP6 - Ultimate (Adapter) mode
 - [ ] GP7 - P+ (Adapter) mode
-- [ ] GP12 - XInput (Leverless Fightstick via Xbox360)
+- [ ] GP12 - Melee (Adapter) mode
 - [ ] GP13 - XInput with Melee
 - [ ] GP14 - XInput (dedicated Xbox360)
 - [ ] GP16 - BOOTSEL

--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ As of this release, 16 modes are built-in.
 
 - GP13 (by default, CLeft) => XInput (Melee DAC algorithm + Xbox360 USB configuration). See lower for mapping.
 
-- GP12 (by default, CUp) => XInput (Xbox360 DAC algorithm + Xbox360 Leverless configuration). See lower for mapping.
+- GP12 (by default, CUp) => Melee GCC to USB adapter mode (Melee F1 DAC algorithm + Adapter USB configuration).
 
-- Plugged into USB, nothing pressed => Melee GCC to USB adapter mode (Melee F1 DAC algorithm + Adapter USB configuration).
+- Plugged into USB, nothing pressed => XInput (Xbox360 DAC algorithm + Xbox360 Leverless configuration). See lower for mapping.
 
 <a name="advisedModes"/>
 
@@ -259,8 +259,8 @@ In this scheme you can only access cardinals and diagonals on the control sticks
 - A => RS Press
 
 - Start => Start (Menu)
-- L and Start => Home (Xbox)
-- L and MY => Back (View)
+- L and R => Home (Xbox)
+- L and B => Back (View)
 - L and Left => Dpad left
 - L and Right => Dpad right
 - L and Up => Dpad up

--- a/src/dac_algorithms/xbox_360.cpp
+++ b/src/dac_algorithms/xbox_360.cpp
@@ -76,9 +76,9 @@ void actuateLeverlessReport(GpioToButtonSets::F1::ButtonSet buttonSet) {
     bool dUp = buttonSet.up && mod;
     bool dDown = buttonSet.down && mod;
 
-    // Start +/- Modifier button -> Home / Photo
-    bool start = buttonSet.start && (!mod);
-    bool home = buttonSet.start && mod;
+    // R +/- Modifier button -> Home / Photo
+    bool r = buttonSet.r && (!mod);
+    bool home = buttonSet.r && mod;
 
     // MX / A / MX + Modifier Button -> LS Press / RS Press / Back
     bool l3 = buttonSet.mx && (!mod);
@@ -90,7 +90,7 @@ void actuateLeverlessReport(GpioToButtonSets::F1::ButtonSet buttonSet) {
     xInputReport.rightStickPress = r3;
     xInputReport.leftStickPress = l3;
     xInputReport.back = back;
-    xInputReport.start = start;
+    xInputReport.start = buttonSet.start;
     xInputReport.dRight = dRight;
     xInputReport.dLeft = dLeft;
     xInputReport.dDown = dDown;
@@ -101,7 +101,7 @@ void actuateLeverlessReport(GpioToButtonSets::F1::ButtonSet buttonSet) {
     xInputReport.pad1 = 0;
     xInputReport.a = buttonSet.b;
     xInputReport.b = buttonSet.x;
-    xInputReport.x = buttonSet.r;
+    xInputReport.x = r;
     xInputReport.y = buttonSet.y;
     xInputReport.leftTrigger = buttonSet.ls ? 255 : 0;
     xInputReport.rightTrigger = buttonSet.ms ? 255 : 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,11 +113,12 @@ int main() {
     if (!gpio_get(14)) USBConfigurations::Xbox360::enterMode([](){
         DACAlgorithms::Xbox360::actuateXbox360Report(GpioToButtonSets::F1::defaultConversion());
     });
-
-    // ? - GP12 - CUp - Leverless/Xbox360 (aka XInput)
-    if (!gpio_get(12)) USBConfigurations::Xbox360::enterMode([](){
-        DACAlgorithms::Xbox360::actuateLeverlessReport(GpioToButtonSets::F1::defaultConversion());
-    });
+    
+    // ? - GP12 - CUp - F1 / melee / adapter
+    if (!gpio_get(12)) USBConfigurations::GccToUsbAdapter::enterMode(
+        [](){USBConfigurations::GccToUsbAdapter::actuateReportFromGCState(DACAlgorithms::MeleeF1::getGCReport(GpioToButtonSets::F1::defaultConversion()));},
+        [](){USBConfigurations::GccToUsbAdapter::actuateReportFromGCState(DACAlgorithms::UltimateF1::getGCReport(GpioToButtonSets::F1::defaultConversion()));}
+    );
 
     // 27 - GP21 - X - Melee / HID
     if (!gpio_get(21)) USBConfigurations::HidWithTriggers::enterMode([](){
@@ -164,9 +165,8 @@ int main() {
         DACAlgorithms::SetOf8Keys::actuate8KeysReport(GpioToButtonSets::F1::defaultConversion());
     });
 
-    // Default: F1 / melee / adapter
-    USBConfigurations::GccToUsbAdapter::enterMode(
-        [](){USBConfigurations::GccToUsbAdapter::actuateReportFromGCState(DACAlgorithms::MeleeF1::getGCReport(GpioToButtonSets::F1::defaultConversion()));},
-        [](){USBConfigurations::GccToUsbAdapter::actuateReportFromGCState(DACAlgorithms::UltimateF1::getGCReport(GpioToButtonSets::F1::defaultConversion()));}
-        );
+    // Default: Leverless/Xbox360 (aka XInput)
+    USBConfigurations::Xbox360::enterMode([](){
+        DACAlgorithms::Xbox360::actuateLeverlessReport(GpioToButtonSets::F1::defaultConversion());
+    });
 }


### PR DESCRIPTION
# Description
Move Xbox360 Leverless mode to default USB Config.

Move Melee GCN Adapter mode to C-Up.

Update Xbox360 Leverless button mapping: swap Start & R when holding mod (Mod + R = Back. Mod + Start = Start)

## Changes
Update Mode Select -> CUp is Melee GCN Adapter on USB
Update Mode Select -> default is Xbox360 Leverless on USB
Update DAC Algorithms -> Xbox360 Leverless button config (swap mod + R with mod + start)

### Affected Modes
#### Console
- [ ] Nothing Pressed - Melee (Joybus) mode
- [ ] GP2 - P+ (Joybus) mode
- [ ] GP6 - Ultimate (Joybus) mode
- [ ] GP7 - P+ mode
#### USB
- [X] Nothing Pressed - XInput (Leverless Fightstick via Xbox360)
- [ ] GP0 - 8KRO Keyboard
- [ ] GP2 - Wired Fight Pad Pro with P+
- [ ] GP4 - Wired Fight Pad Pro (dedicated)
- [ ] GP5 - Wired Fight Pad Pro with Melee
- [ ] GP6 - Ultimate (Adapter) mode
- [ ] GP7 - P+ (Adapter) mode
- [X] GP12 - Melee (Adapter) mode
- [ ] GP13 - XInput with Melee
- [ ] GP14 - XInput (dedicated Xbox360)
- [ ] GP16 - BOOTSEL
- [ ] GP17 - Runtime Remapping
- [ ] GP20 - HID Controller with P+
- [ ] GP21 - HID Controller with Melee
- [ ] GP22 - HID Controller with Ultimate
- [ ] Any other future modes using the Xbox360 DAC Algorithm

### Testing done
- Verified via Gamepad Tester site