### PR TITLE
Allow Start + Back at same time on Xbox360 + Leverless

### DIFF
--- a/src/dac_algorithms/xbox_360.cpp
+++ b/src/dac_algorithms/xbox_360.cpp
@@ -76,19 +76,18 @@ void actuateLeverlessReport(GpioToButtonSets::F1::ButtonSet buttonSet) {
     bool dUp = buttonSet.up && mod;
     bool dDown = buttonSet.down && mod;
 
-    // R +/- Modifier button -> Home / Photo
+    // R / R + Modifier button -> R / Home
     bool r = buttonSet.r && (!mod);
     bool home = buttonSet.r && mod;
 
-    // MX / A / MX + Modifier Button -> LS Press / RS Press / Back
-    bool l3 = buttonSet.mx && (!mod);
-    bool r3 = buttonSet.a;
-    bool back = buttonSet.mx && mod;
+    // B / B + Modifier Button -> B / Back
+    bool back = buttonSet.b && mod;
+    bool b = buttonSet.b && !(mod);
 
     USBConfigurations::Xbox360::ControllerReport &xInputReport = USBConfigurations::Xbox360::xInputReport;
     xInputReport.reportId = 0;
-    xInputReport.rightStickPress = r3;
-    xInputReport.leftStickPress = l3;
+    xInputReport.rightStickPress = buttonSet.a;
+    xInputReport.leftStickPress = buttonSet.mx;
     xInputReport.back = back;
     xInputReport.start = buttonSet.start;
     xInputReport.dRight = dRight;
@@ -99,7 +98,7 @@ void actuateLeverlessReport(GpioToButtonSets::F1::ButtonSet buttonSet) {
     xInputReport.zr = zr;
     xInputReport.home = home;
     xInputReport.pad1 = 0;
-    xInputReport.a = buttonSet.b;
+    xInputReport.a = b;
     xInputReport.b = buttonSet.x;
     xInputReport.x = r;
     xInputReport.y = buttonSet.y;


### PR DESCRIPTION
# Description

Allow Start + Back at same time on Xbox360 + Leverless

### Affected Modes
Check the boxes for any mode that is affected by your changes. Make sure to note if these will apply to future modes using a certain DAC algorithm, Communications Protocol, or Button Set.
#### Console
- [ ] Nothing Pressed - Melee (Joybus) mode
- [ ] GP2 - P+ (Joybus) mode
- [ ] GP6 - Ultimate (Joybus) mode
- [ ] GP7 - P+ mode
#### USB
- [ ] Nothing Pressed - Melee (Adapter) mode
- [ ] GP0 - 8KRO Keyboard
- [ ] GP2 - Wired Fight Pad Pro with P+
- [ ] GP4 - Wired Fight Pad Pro (dedicated)
- [ ] GP5 - Wired Fight Pad Pro with Melee
- [ ] GP6 - Ultimate (Adapter) mode
- [ ] GP7 - P+ (Adapter) mode
- [X] GP12 - XInput (Leverless Fightstick via Xbox360)
- [ ] GP13 - XInput with Melee
- [ ] GP14 - XInput (dedicated Xbox360)
- [ ] GP16 - BOOTSEL
- [ ] GP17 - Runtime Remapping
- [ ] GP20 - HID Controller with P+
- [ ] GP21 - HID Controller with Melee
- [ ] GP22 - HID Controller with Ultimate
- [ ] Any other future modes using the Xbox360 DAC Algorithm

### Testing done
Include the steps you took to verify that your changes are operating as intended. Make sure you've covered all possible regressions.
- Verified behavior